### PR TITLE
fix: generate_uuid now returns UUID as output

### DIFF
--- a/generate_uuid/generate_uuid.sh
+++ b/generate_uuid/generate_uuid.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 generate_uuid () {
-    uuid=$(cat /proc/sys/kernel/random/uuid)
+    cat /proc/sys/kernel/random/uuid
 }

--- a/generate_uuid/test_generate_uuid.sh
+++ b/generate_uuid/test_generate_uuid.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+source ./generate_uuid.sh
+
+gen_uuid=$(generate_uuid)
+echo "generated UUID: $gen_uuid"


### PR DESCRIPTION
The previous version of the `generate_uuid` function generated the UUID and assigned to a variable, but never returned it.

Now, the *generated* UUID is returned as output of the `generate_uuid` function.